### PR TITLE
Onboarding capi-approvers for cf-performance-tests pipelines

### DIFF
--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -17,7 +17,7 @@ dns_domain: ci.cloudfoundry.org
 gke_name: wg-ci
 
 # Concourse teams
-concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers"
+concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers\\,cloudfoundry:wg-app-runtime-interfaces-capi-approvers"
 concourse_github_mainTeamUser: ""
 
 # Concourse helm chart


### PR DESCRIPTION
Onboard CAPI approvers for the cf-performance-tests pipelines, with this PR, CAPI approvers will be part of the main team that can manage those pipelines.