### PR TITLE
Make nat-ips configurable

### DIFF
--- a/terraform-modules/concourse/infra/variables.tf
+++ b/terraform-modules/concourse/infra/variables.tf
@@ -49,6 +49,11 @@ variable "gke_workers_pool_ssd_count" { nullable = false }
 variable "gke_subnet_cidr" { nullable = false }
 variable "gke_cloud_nat_min_ports_per_vm" { nullable = false }
 
+variable "gke_use_static_nat_ips" {
+  nullable = false
+  default = false
+}
+
 variable "gke_http_load_balancing_disabled" { nullable = false }
 
 variable "github_secret_name" { nullable = false }


### PR DESCRIPTION
Add a config parameter, which allows to make the nat-ips for egress traffic of the kubernetes cluster static. This is useful if any service within the cluster needs to access another system, which is using ip whitelists. If the ips are not static, they might change over time and with that the whitelists need to be adjusted. Our specific usecase is having a concourse running in the cluster, which accesses systems which have ip whitelists.

The config parameter is optional and by default `false`, which reflects the state before the change. The nat-ips will be automatically assigned. If the parameter is set to true, two external ips will be reserved and assigned to the nat routers.