### PR TITLE
Add K8s Cron Job to automatically renew certificates

### DIFF
--- a/terraform-modules/concourse/automatic_certificate_regeneration/cron_job.tf
+++ b/terraform-modules/concourse/automatic_certificate_regeneration/cron_job.tf
@@ -1,0 +1,58 @@
+resource "kubernetes_cron_job_v1" "automatic_certificate_regeneration" {
+  metadata {
+    name = "certificate-regeneration"
+    namespace = "concourse"
+  }
+  spec {
+    schedule                      = "@monthly"
+    failed_jobs_history_limit     = 2
+    successful_jobs_history_limit = 2
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata {}
+          spec {
+            restart_policy = "OnFailure"
+            container {
+              name              = "cert-regen"
+              image             = "yatzek/credhub-cli:2.9.0"
+              image_pull_policy = "IfNotPresent"
+              command           = ["bash", "-c", "IFS=',' read -r -a CERTIFICATES <<< \"$CERTS_TO_RENEW\"; for cert in \"$${CERTIFICATES[@]}\"; do credhub regenerate -n \"$cert\"; done"]
+              env {
+                name  = "CERTS_TO_RENEW"
+                value = var.certificates_to_regenerate
+              }
+              env {
+                name  = "CREDHUB_SERVER"
+                value = "https://credhub.concourse.svc.cluster.local:9000"
+              }
+              env {
+                name = "CREDHUB_CA_CERT"
+                value_from {
+                  secret_key_ref {
+                    key  = "certificate"
+                    name = "credhub-root-ca"
+                  }
+                }
+              }
+              env {
+                name  = "CREDHUB_CLIENT"
+                value = "credhub_admin_client"
+              }
+              env {
+                name = "CREDHUB_SECRET"
+                value_from {
+                  secret_key_ref {
+                    key  = "password"
+                    name = "credhub-admin-client-credentials"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-modules/concourse/automatic_certificate_regeneration/providers.tf
+++ b/terraform-modules/concourse/automatic_certificate_regeneration/providers.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+data "google_client_config" "provider" {}
+
+data "google_container_cluster" "wg_ci" {
+  project  = var.project
+  name     = var.gke_name
+  location = var.zone
+}
+
+provider "kubernetes" {
+  host  = "https://${data.google_container_cluster.wg_ci.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.wg_ci.master_auth[0].cluster_ca_certificate)
+}

--- a/terraform-modules/concourse/automatic_certificate_regeneration/variables.tf
+++ b/terraform-modules/concourse/automatic_certificate_regeneration/variables.tf
@@ -1,0 +1,7 @@
+variable "project" { nullable = false }
+variable "region" { nullable = false }
+variable "zone" { nullable = false }
+
+variable "gke_name" { nullable = false }
+
+variable "certificates_to_regenerate" { nullable = false }

--- a/terragrunt/concourse-wg-ci-test/automatic_certificate_regeneration/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci-test/automatic_certificate_regeneration/terragrunt.hcl
@@ -1,0 +1,34 @@
+locals {
+  config = yamldecode(file("../config.yaml"))
+}
+
+remote_state {
+  backend = "gcs"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+  config = {
+    bucket         = "${local.config.gcs_bucket}"
+    prefix         = "${local.config.gcs_prefix}/automatic-certificate-regeneration"
+    project        = "${local.config.project}"
+    location       = "${local.config.region}"
+    # use for uniform bucket-level access
+    # (https://cloud.google.com/storage/docs/uniform-bucket-level-access)
+    enable_bucket_policy_only = false
+  }
+}
+
+terraform {
+  source = local.config.tf_modules.automatic_certificate_regeneration
+}
+
+inputs = {
+  project = local.config.project
+  region  = local.config.region
+  zone    = local.config.zone
+
+  gke_name = local.config.gke_name
+
+  certificates_to_regenerate = local.config.certificates_to_regenerate
+}

--- a/terragrunt/concourse-wg-ci-test/config.yaml
+++ b/terragrunt/concourse-wg-ci-test/config.yaml
@@ -44,6 +44,7 @@ tf_modules:
   dr_restore: "../../..//terraform-modules/concourse/dr_restore"
   e2e_test:   "../../..//terraform-modules/concourse/e2e_test"
   secret_rotation_postgresql: "../../..//terraform-modules/concourse/secret_rotation_postgresql"
+  automatic_certificate_regeneration: "../../..//terraform-modules/concourse/automatic_certificate_regeneration"
 
 
 fly_team: main
@@ -122,3 +123,7 @@ wg_ci_cnrm_service_account_permissions: [
     "cloudsql.databases.list",
     "cloudsql.databases.update"
   ]
+
+# list of certificates that shall be automatically renewed every month
+# enter as one string with a comma-separated list of CredHub certificate names
+certificates_to_regenerate: "/concourse/main/test_cert"


### PR DESCRIPTION
* new config variable to specify list of certificates stored in CredHub
* K8s Cron Job will run every month and call `credhub regenerate` to renew the specified certificates

PR is created as draft for initial review. Changes have been tested on the "wg-ci-test" instance. For the final PR, I would copy the Terragrunt module to "wg-ci" and add a README with instructions.

TBD:
* new terragrunt module is now part of the full stack, better rename the `.hcl` file similar to `secret_rotation_postgresql/rotate.hcl`?