### PR TITLE
Use cf-deployment-concourse-tasks Docker image for CredHub operations

### DIFF
--- a/terraform-modules/concourse/automatic_certificate_regeneration/cron_job.tf
+++ b/terraform-modules/concourse/automatic_certificate_regeneration/cron_job.tf
@@ -16,7 +16,7 @@ resource "kubernetes_cron_job_v1" "automatic_certificate_regeneration" {
             restart_policy = "OnFailure"
             container {
               name              = "cert-regen"
-              image             = "yatzek/credhub-cli:2.9.0"
+              image             = "cloudfoundry/cf-deployment-concourse-tasks:v19.0.0"
               image_pull_policy = "IfNotPresent"
               command           = ["bash", "-c", "IFS=',' read -r -a CERTIFICATES <<< \"$CERTS_TO_RENEW\"; for cert in \"$${CERTIFICATES[@]}\"; do credhub regenerate -n \"$cert\"; done"]
               env {

--- a/terraform-modules/concourse/e2e_test/credhub_test_secret_k8s.tf
+++ b/terraform-modules/concourse/e2e_test/credhub_test_secret_k8s.tf
@@ -40,7 +40,7 @@ resource "kubernetes_job" "credhub_cli" {
       spec {
         restart_policy = "Never"
         container {
-          image = "yatzek/credhub-cli:2.9.0"
+          image = "cloudfoundry/cf-deployment-concourse-tasks:v19.0.0"
           name  = "credhub-cli"
 
           command = [

--- a/terraform-modules/concourse/e2e_test/pipeline.yml
+++ b/terraform-modules/concourse/e2e_test/pipeline.yml
@@ -13,8 +13,8 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: yatzek/credhub-cli
-          tag: 2.9.0
+          repository: cloudfoundry/cf-deployment-concourse-tasks
+          tag: v19.0.0
       run:
         path: bash
         args:

--- a/terragrunt/scripts/concourse/start-credhub-cli.sh
+++ b/terragrunt/scripts/concourse/start-credhub-cli.sh
@@ -25,7 +25,7 @@ credhub_secret="$(kubectl --namespace concourse get secret credhub-admin-client-
 kubectl run credhub-cli-"$(openssl rand -hex 4)" \
         --rm -i -t \
         --restart=Never \
-        --image=yatzek/credhub-cli:2.9.0 \
+        --image=cloudfoundry/cf-deployment-concourse-tasks:v19.0.0 \
         --env="CREDHUB_SERVER=$credhub_server" \
         --env="CREDHUB_CA_CERT=$credhub_ca_cert" \
         --env="CREDHUB_CLIENT=$credhub_client" \


### PR DESCRIPTION
* Proposed by TOC: Use an image that is under control of the "cloudfoundry" organization for critical operations

I've tested `start-credhub-cli.sh`, works. I've also run `terragrunt apply --terragrunt-config cert_regen.hcl` on the `wg-ci-test` instance, works.

If this is PR is accepted, the `wg-ci` certificate rotation and the e2e tests must be updated.