### PR TITLE
Update productive ARI WG Concourse

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,12 +1,12 @@
-concourse 7.11.2
+concourse 7.12.0
 gcloud 469.0.0
 helm 3.14.3
 kapp 0.60.0
 kubectl 1.29.3
 python 3.12.2
-terraform 1.7.5
+terraform 1.10.2
 terraform-lsp 0.0.12
-terragrunt 0.55.19
+terragrunt 0.70.4
 vendir 0.40.0
 yq 4.43.1
 ytt 0.44.1

--- a/docs/concourse/README.md
+++ b/docs/concourse/README.md
@@ -98,6 +98,11 @@ The following command needs to be run from within your root directory (containin
 terragrunt run-all apply
 ```
 
+*NOTE: Make sure that your Terragrunt TFPATH points to the "terraform" CLI and not to the "tofu" CLI. Tofu uses a different versioning scheme and may fail to load some plugins that check for a specific Terraform version:
+```sh
+export TERRAGRUNT_TFPATH=/Users/<your user id>/.asdf/shims/terraform
+```
+
 #### 5. Configure your local kubectl afterwards
   1. Login into the google cloud via `gcloud auth login && gcloud auth application-default login`.
   2. Configure you kubectl, see section [How to obtain GKE credentials for your terminal](<#how-to-obtain-gke-credentials-for-your-terminal>).

--- a/terraform-modules/actions_runner_controller/infra/providers.tf
+++ b/terraform-modules/actions_runner_controller/infra/providers.tf
@@ -7,7 +7,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "registry.terraform.io/gavinbunney/kubectl"
     }
     github = {
       source = "integrations/github"

--- a/terraform-modules/actions_runner_controller/team/providers.tf
+++ b/terraform-modules/actions_runner_controller/team/providers.tf
@@ -7,7 +7,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "registry.terraform.io/gavinbunney/kubectl"
     }
     github = {
       source  = "integrations/github"

--- a/terraform-modules/concourse/app/providers.tf
+++ b/terraform-modules/concourse/app/providers.tf
@@ -4,7 +4,8 @@ terraform {
       source = "hashicorp/google"
     }
     carvel = {
-      source = "vmware-tanzu/carvel"
+      source = "registry.terraform.io/vmware-tanzu/carvel"
+      version = "= 0.11.0"
     }
   }
 }

--- a/terraform-modules/concourse/backend/providers.tf
+++ b/terraform-modules/concourse/backend/providers.tf
@@ -4,10 +4,11 @@ terraform {
       source = "hashicorp/google"
     }
     carvel = {
-      source = "vmware-tanzu/carvel"
+      source = "registry.terraform.io/vmware-tanzu/carvel"
+      version = "= 0.11.0"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "registry.terraform.io/gavinbunney/kubectl"
     }
   }
 }

--- a/terraform-modules/concourse/infra/providers.tf
+++ b/terraform-modules/concourse/infra/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "registry.terraform.io/gavinbunney/kubectl"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -21,7 +21,7 @@ concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-ap
 concourse_github_mainTeamUser: ""
 
 # Concourse helm chart
-concourse_helm_version: "17.2.0"
+concourse_helm_version: "17.4.0"
 
 # Module sources for the stack - git or local
 # ie.
@@ -60,6 +60,7 @@ gke_default_pool_ssd_count: 0
 # typical config for concourse worker is n4-standard-4 and ssd_count: 1
 # note: economy e2-standard machine can't use local ssd drives
 gke_workers_pool_machine_type: n2-standard-4
+gke_workers_min_memory: 4Gi
 gke_workers_pool_node_count: 4
 gke_workers_pool_autoscaling_max: 4
 gke_workers_pool_ssd_count: 1

--- a/terragrunt/concourse-wg-ci/infra/.terraform.lock.hcl
+++ b/terragrunt/concourse-wg-ci/infra/.terraform.lock.hcl
@@ -1,21 +1,5 @@
-# This file is maintained automatically by "tofu init".
+# This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
-
-provider "registry.opentofu.org/gavinbunney/kubectl" {
-  version = "1.14.0"
-  hashes = [
-    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
-    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
-    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
-    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
-    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
-    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
-    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
-    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
-    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
-    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
-  ]
-}
 
 provider "registry.opentofu.org/hashicorp/google" {
   version = "5.20.0"
@@ -51,19 +35,81 @@ provider "registry.opentofu.org/hashicorp/google-beta" {
   ]
 }
 
-provider "registry.opentofu.org/hashicorp/kubernetes" {
-  version = "2.27.0"
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version = "1.18.0"
   hashes = [
-    "h1:sQ413yweMfNSLmWSFzUXiBnSfH7NlrPWaPIRERV7mRg=",
-    "zh:1146f53fb39fd4bcea5574303c4871001a97d7891f65a60a4ecbc64da2a90d75",
-    "zh:1f7e3dc0dbb854f56a0f5ba3c50588272984ae9775da027c3c7f32cb6d8245b0",
-    "zh:2166f7fdade75266658603280bc822edab848e52a674340485847dde1c5d9324",
-    "zh:21a97530857330d2013aa66fb7afebb44fe4a5543418d0a3ca93750acd11fea5",
-    "zh:2d4b9fea7e99750647e1cd8df9a67cba45905825867dd19ab01411dad6b8c6fd",
-    "zh:de30e92e638b95e56dbb2232cb9a6f6a69346ecb3644965e9be715eaf29f22ff",
-    "zh:f4ae951c9add4349a498f44c3f5768cbaf7a966392a0e7632de288889e7cd5d9",
-    "zh:f54ecb1917dfa198933d72632ea6f0aa4da3ead070d6b9765ec1d3b7da60e827",
-    "zh:fba8a2f192eb5fe248708b9037db046e0d9176e7c54c6edc6f6aa55d50474082",
-    "zh:fe525956f3e54f0bbd2891a6abad1f807b4763b8dc734d810e223876741fefa3",
+    "h1:ysfCsOcDtkzbCicRpBb7jm0Dj5H4n1/Q0LiVAPHkQME=",
+    "zh:06721b083cceb1c8c43535b21879e32b25ce22d4d2dac9c9d7717349ef97a1b0",
+    "zh:172eaf0d7a1b536e454c9b066a7aaf1027b51a1ca6f1d5918055c3da11055c9f",
+    "zh:2c34140c46674971bc2dd45f84c9701e86654b8c6b019c5a0ff26c4f111232c4",
+    "zh:3dc5623d74a5f373bff189b2939aa05d6b48c9d5070b20c6514c05c0c2b3d1bc",
+    "zh:4f4169427d5f13348e378cdb1cebd4c34914a8aaa0a6fc42b5aa63df76ca1e47",
+    "zh:8ceecf5c01a4f72f3f26ffaaa56a5a73660d8eb4c382c9066dfa82166e63df93",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a01fbfb974d7b6c54db71efb5e35d3ea54aed48c147220b0fde8a9c91db55667",
+    "zh:bb6428db2b84e814c1c4cb59006dcc47177c0c6c90d92eabfd33e535525d6e28",
+    "zh:c3163db5b43fa303e9058fab1c49e590f19bbb984b1f4704b0678c050cb4ab17",
+    "zh:ce57a14f0b8f6ecafa2623ff3ce08a87398fcc26cd072645334334ec4a176075",
+    "zh:cfb135b0488b76be5a016299730da749fd9493200ca43ac13c57c665e43eecd7",
+    "zh:d0b0fa3aac0be376e429206414be6a37a05e926699d258f55d81bdc531959482",
+    "zh:d6b7df802d4344b6bbc41777788fa6917dcf7cb6e2c9cceeff434f5930a44df1",
+    "zh:fd1e6d5fa802723dfb26a87405117dca70530b168222f2fbd62075e91f748e18",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.14.1"
+  hashes = [
+    "h1:zhyWKVVqORklT7c28f6FzZ0z/g6pGa6FFtv/wp1MKDc=",
+    "zh:0a0cab3291bdac20fe31511b7aa9f3258b14add16d13110d4ebac18761277361",
+    "zh:178594db6fbff9974a7c65c65195a64c93d16f652a1a4136015b192faaa1ce2d",
+    "zh:379bbd6bd5b8add55ffd46c99a8081664e9004188f6df91f8f044e4268b86e42",
+    "zh:4899b6174a4492dbff3d94f56a901692a3f8d86a6db9de6a92b83d43b7ad4507",
+    "zh:6240820c3aeeaa8b9830fb4514d3ecb6e3fed8724340dfedaf89b4bb2265102f",
+    "zh:9a214e052c5c7b4e7bc409086832d4bd8e404b652b66344c26c314747c49744f",
+    "zh:a6cb9da102d371a52b750de5628a2b6b7cc7c20481d7fa3fb25a957b58b05777",
+    "zh:ab69d69f9c16461105a585f8a9c780eb06238827db269c5ad3f7c114922e7f20",
+    "zh:b716e219779295e9af2b632b2c0d534c90cca5c87352fc0c6dc8ebae671dd4d2",
+    "zh:d96e8d6c3109882d5527956acad12015a024fc24a6110e244007209b4f3069a0",
+    "zh:f49274564725189932a65cf1a4e8f40f46fca2537da7a673da9fea6ff7e3f195",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "6.14.1"
+  hashes = [
+    "h1:1+sMdTNhss2GMmmjPtHV0v378dWq8A+naQH+Y0XQAi4=",
+    "zh:0d744a644446bb1327b3b5dc3b1b4007ae9be75a819e0938b3bb226d5ede2f1f",
+    "zh:0dcd29479c85fa8830da2e5085e5957d0a13e315004c81f3cfc25a94f0dbb398",
+    "zh:33b122c2b95458beec16f5365153bc83c216391f8abd0e97651cb070e90e5172",
+    "zh:64d8b2534fe3087068cd6d72ea864f03102b5c63a858630c9bb69ef7790ca9c0",
+    "zh:693ddcce59ab94780619b0a113039798176cd0b3713c49378b99ecf31116a79d",
+    "zh:79fb60be39b4bea142ba135a3415db69e4a1fcf8070812609dc8c55682013afd",
+    "zh:979dffaa49252b3c0d7040afd1554f4e7ee5f64f1271e497416b8405ac6caa97",
+    "zh:9fadf71658d89d8e3c0055642404242dd6794cdfca6a5052d8b2acafa9c4c71c",
+    "zh:c6c1afa039ea87f607040f81c711e6fdd0daae0db59237f4a69138643f64379f",
+    "zh:e63d14748825c8d680a30b73d7c5d43e25a6724786701b1c43e734ff86aabb32",
+    "zh:e84138767ad8bdb8f682b9af679f8f0e212c0bd2c73124143f062ecdcd4678d1",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.35.0"
+  hashes = [
+    "h1:r0Fs327r5OSmrFAJPcJC6wgpJqmJbZGNL7EAMeA1g+Y=",
+    "zh:059080ce30d4bf47ebce3bd09202c7f0e8fd7e734aeb2ace3dfbd1f1266c723c",
+    "zh:43f99c88ab344a8c108335a085483c8a786ff3194fe6acc279c1f4d8ff7a6603",
+    "zh:922aaa5766dacd0e4ef6eb401da538fe8d0ad1e79bfbb8e17dbfe86e6182d746",
+    "zh:a42b96a4570a1ba16556362a834a879d433395c8f1d8f24c0fc33c2cfd2065d9",
+    "zh:bf4271cc0f3cd81a1db34c150799cbe09ed6a131b185962a36a1e675767ef681",
+    "zh:c68cdb3c3b8aaf177af40e1cd1000d09e3a17d2610d8a125e4e6bf479d2efb71",
+    "zh:cf10a45e702af18fdec4fab30d8e6c447ab5cefa1ca9e2c94a3c9e802b7759c8",
+    "zh:d975dab312d2097700da1ea7aab1c1190e2acd99e5248f9be881093df2312bf4",
+    "zh:e297fdcb2ec49c7c77f1b2d793a7a6edaf6d9153036eb2aeaff9a3f4b9686bfa",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f607aa5b080a317c5ed353713cc33a4b3735e98bd4f4c15d33b494ae193db0b2",
+    "zh:f82baadbd4de5d3e4871672945be843a6540a339772b63db6dc3304860a4d97d",
   ]
 }


### PR DESCRIPTION
Draft PR for collecting all changes to make `terragrunt run-all apply` pass for the productive "wg-ci" instance.