### PR TITLE
Make worker pod memory limit configurable

### DIFF
--- a/terraform-modules/concourse/app/concourse.tf
+++ b/terraform-modules/concourse/app/concourse.tf
@@ -61,9 +61,9 @@ data "carvel_ytt" "concourse_app" {
   values = {
     "google.project_id" = var.project
     "google.region"     = var.region
+    "workers"           = var.gke_workers_max_memory
   }
- }
-
+}
 
 resource "carvel_kapp" "concourse_app" {
   app          = "concourse-app"

--- a/terraform-modules/concourse/app/files/config/concourse/pod_resources_limits.yml
+++ b/terraform-modules/concourse/app/files/config/concourse/pod_resources_limits.yml
@@ -1,0 +1,14 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "concourse-worker"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by=overlay.subset({"name": "concourse-worker"})
+        - resources:
+            #@overlay/match missing_ok=True
+            limits:
+              memory: #@ data.values.workers

--- a/terraform-modules/concourse/app/variables.tf
+++ b/terraform-modules/concourse/app/variables.tf
@@ -6,6 +6,7 @@ variable "gke_name" { nullable = false }
 variable "gke_workers_pool_machine_type" { nullable = false }
 variable "gke_workers_pool_node_count" { nullable = false }
 variable "gke_workers_min_memory" { nullable = false }
+variable "gke_workers_max_memory" { nullable = false }
 variable "gke_default_pool_node_count" { nullable = false }
 
 variable "concourse_helm_version" { nullable = false }

--- a/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
@@ -43,6 +43,7 @@ inputs = {
   gke_workers_pool_machine_type = local.config.gke_workers_pool_machine_type
   gke_workers_pool_node_count = local.config.gke_workers_pool_node_count
   gke_workers_min_memory = local.config.gke_workers_min_memory
+  gke_workers_max_memory = local.config.gke_workers_max_memory
   gke_default_pool_node_count = local.config.gke_default_pool_node_count
 
   load_balancer_ip = dependency.infra.outputs.load_balancer_ip

--- a/terragrunt/concourse-wg-ci-test/config.yaml
+++ b/terragrunt/concourse-wg-ci-test/config.yaml
@@ -75,6 +75,7 @@ gke_default_pool_ssd_count: 0
 # note: economy e2-standard machine can't use local ssd drives
 gke_workers_pool_machine_type: e2-standard-4
 gke_workers_min_memory: 1024Mi
+gke_workers_max_memory: 4Gi
 gke_workers_pool_node_count: 1
 gke_workers_pool_autoscaling_max: 4
 gke_workers_pool_ssd_count: 0

--- a/terragrunt/concourse-wg-ci/app/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci/app/terragrunt.hcl
@@ -43,6 +43,7 @@ inputs = {
   gke_workers_pool_machine_type = local.config.gke_workers_pool_machine_type
   gke_workers_pool_node_count = local.config.gke_workers_pool_node_count
   gke_workers_min_memory = local.config.gke_workers_min_memory
+  gke_workers_max_memory = local.config.gke_workers_max_memory
   gke_default_pool_node_count = local.config.gke_default_pool_node_count
 
   load_balancer_ip = dependency.infra.outputs.load_balancer_ip

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -61,6 +61,7 @@ gke_default_pool_ssd_count: 0
 # note: economy e2-standard machine can't use local ssd drives
 gke_workers_pool_machine_type: n2-standard-4
 gke_workers_min_memory: 4Gi
+gke_workers_max_memory: 12Gi
 gke_workers_pool_node_count: 4
 gke_workers_pool_autoscaling_max: 4
 gke_workers_pool_ssd_count: 1


### PR DESCRIPTION
* the Concourse Helm chart does not provide a configuration parameter for memory limit: https://github.com/concourse/concourse-chart
* so use a small ytt config file to merge "resources.limits.memory" into the "concourse-worker" deployment