### PR TITLE
Update carvel terraform provider and documentation

### DIFF
--- a/docs/concourse/README.md
+++ b/docs/concourse/README.md
@@ -209,20 +209,6 @@ terragrunt run-all destroy
 
 Delete terraform state gcp bucket from GCP console or via `gsutil`
 
-### Carvel kapp terraform provider not available for Apple M1
-https://github.com/vmware-tanzu/terraform-provider-carvel/issues/30#issuecomment-1311465417
-
-To compile the provider locally, clone the repository https://github.com/carvel-dev/terraform-provider and run:
-```
-go mod tidy
-go build -o terraform-provider-carvel ./cmd/main.go
-```
-Then copy the binary into the local Terraform "plugins" folder:
-```
-cp ./terraform-provider-carvel ~/.terraform.d/plugins/registry.terraform.io/vmware-tanzu/carvel/0.11.0/darwin_arm64
-```
-In case of Terraform checksum mismatches, go to a Terraform module and run "terraform init" to fix the checksums.
-
 ### Plan/apply terragrunt for a specific component of the stack
 
 ```sh

--- a/docs/concourse/concourse_minor_version_upgrade.md
+++ b/docs/concourse/concourse_minor_version_upgrade.md
@@ -11,7 +11,7 @@ Please note the process should be also useful for upgrading major versions.
 1. Connect to your GCP account
    ```
    gcloud auth login && gcloud auth application-default login
-   gcloud set project <your project name>
+   gcloud config set project <your project name>
    ```
 
 2. `cd` to a folder with concourse folder with `config.yaml` file
@@ -34,7 +34,7 @@ Please note the process should be also useful for upgrading major versions.
 
 6. Apply roll-out for new Concourse version
    ```
-   terragrunt run-all plan --terragrunt-source-update
+   terragrunt run-all apply --terragrunt-source-update
    ```
 
 At this point depending on your use case:

--- a/terraform-modules/concourse/app/providers.tf
+++ b/terraform-modules/concourse/app/providers.tf
@@ -4,7 +4,7 @@ terraform {
       source = "hashicorp/google"
     }
     carvel = {
-      source = "registry.terraform.io/vmware-tanzu/carvel"
+      source = "registry.terraform.io/carvel-dev/carvel"
     }
   }
 }

--- a/terraform-modules/concourse/backend/providers.tf
+++ b/terraform-modules/concourse/backend/providers.tf
@@ -4,7 +4,7 @@ terraform {
       source = "hashicorp/google"
     }
     carvel = {
-      source = "registry.terraform.io/vmware-tanzu/carvel"
+      source = "registry.terraform.io/carvel-dev/carvel"
     }
     kubectl = {
       source = "registry.terraform.io/gavinbunney/kubectl"


### PR DESCRIPTION
on [Terraform registry](https://registry.terraform.io/providers/vmware-tanzu/carvel/latest) the carvel provider has not been updated for the last 3 years. We have already [0.11.2](https://github.com/carvel-dev/terraform-provider-carvel/releases/tag/v0.11.2) out which supports arm64 provider for arm64 arch.  In this project, we used the outdated/unmaintained provider and this PR aim to replace it with [0.11.2](https://github.com/carvel-dev/terraform-provider-carvel/releases/tag/v0.11.2). 

Error before this PR:

```
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/vmware-tanzu/carvel v0.11.0 does not have a
│ package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from OpenTofu CLI releases, so not all
│ providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
```

After updating we are getting output:
```
Initializing provider plugins...
- Finding latest version of hashicorp/google...
- Finding latest version of vmware-tanzu/carvel...
- Finding latest version of hashicorp/kubernetes...
- Finding latest version of hashicorp/helm...
- Finding latest version of registry.terraform.io/carvel-dev/carvel...
- Installing hashicorp/helm v2.17.0...
- Installed hashicorp/helm v2.17.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing registry.terraform.io/carvel-dev/carvel v0.11.2...
[WARN] Provider carvel-dev/carvel (registry.terraform.io) gpg key expired, this will fail in future versions of OpenTofu
- Installed registry.terraform.io/carvel-dev/carvel v0.11.2 (signed, key ID 9FD834C948074CE9)
- Installing hashicorp/google v6.27.0...
- Installed hashicorp/google v6.27.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing vmware-tanzu/carvel v0.11.2...
- Installed vmware-tanzu/carvel v0.11.2. Signature validation was skipped due to the registry not containing GPG keys for this provider
- Installing hashicorp/kubernetes v2.36.0...
- Installed hashicorp/kubernetes v2.36.0 (signed, key ID 0C0AF313E5FD9F80)
```

@jochenehret  only question is that should we worry about this provider too as it gpg are expired and warn us that it will fail for future openTofu versions:
```
[WARN] Provider carvel-dev/carvel (registry.terraform.io) gpg keys are expired, this will fail in future versions of OpenTofu

```