### PR TITLE
Make Helm chart "worker.minAvailable" parameter configurable

### DIFF
--- a/terraform-modules/concourse/app/concourse.tf
+++ b/terraform-modules/concourse/app/concourse.tf
@@ -47,6 +47,11 @@ data "helm_template" "concourse" {
   }
 
   set {
+    name = "worker.minAvailable"
+    value = var.gke_workers_min_available
+  }
+
+  set {
     name = "web.replicas"
     value = var.gke_default_pool_node_count
   }

--- a/terraform-modules/concourse/app/variables.tf
+++ b/terraform-modules/concourse/app/variables.tf
@@ -5,6 +5,7 @@ variable "zone" { nullable = false }
 variable "gke_name" { nullable = false }
 variable "gke_workers_pool_machine_type" { nullable = false }
 variable "gke_workers_pool_node_count" { nullable = false }
+variable "gke_workers_min_available" { nullable = false }
 variable "gke_workers_min_memory" { nullable = false }
 variable "gke_workers_max_memory" { nullable = false }
 variable "gke_default_pool_node_count" { nullable = false }

--- a/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
@@ -42,6 +42,7 @@ inputs = {
   gke_name = local.config.gke_name
   gke_workers_pool_machine_type = local.config.gke_workers_pool_machine_type
   gke_workers_pool_node_count = local.config.gke_workers_pool_node_count
+  gke_workers_min_available = local.config.gke_workers_min_available
   gke_workers_min_memory = local.config.gke_workers_min_memory
   gke_workers_max_memory = local.config.gke_workers_max_memory
   gke_default_pool_node_count = local.config.gke_default_pool_node_count

--- a/terragrunt/concourse-wg-ci-test/config.yaml
+++ b/terragrunt/concourse-wg-ci-test/config.yaml
@@ -80,6 +80,7 @@ gke_default_pool_ssd_count: 0
 gke_workers_pool_machine_type: e2-standard-4
 gke_workers_min_memory: 1024Mi
 gke_workers_max_memory: 4Gi
+gke_workers_min_available: 0
 gke_workers_pool_node_count: 1
 gke_workers_pool_autoscaling_max: 4
 gke_workers_pool_ssd_count: 0


### PR DESCRIPTION
* can be used to set "spec.minAvailable" to 0 in the K8s PodDisruptionBudget (to unblock GKE maintance operations)