### PR TITLE
Add buildpack reviewers to list of teams

### DIFF
--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -17,7 +17,7 @@ dns_domain: ci.cloudfoundry.org
 gke_name: wg-ci
 
 # Concourse teams
-concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers\\,cloudfoundry:wg-app-runtime-interfaces-capi-approvers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-node-js-reviewers"
+concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers\\,cloudfoundry:wg-app-runtime-interfaces-capi-approvers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-node-js-reviewers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-node-js-approvers"
 concourse_github_mainTeamUser: ""
 
 # Concourse worker placement strategy: https://concourse-ci.org/container-placement.html


### PR DESCRIPTION
* grant permission to buildpack reviewers
* only added "node-js" team as other buildpack teams contain the same member list