### PR TITLE
parameterize deletion protection for SQL instance, credhub secret and…

### DIFF
--- a/docs/concourse/region_change.md
+++ b/docs/concourse/region_change.md
@@ -36,11 +36,13 @@ For cost saving reasons, you can migrate the Concourse deployment to a different
    :warning: The file `credhub_backup.json` contains sensitive data in plaintext, so handle it with care and delete it after the migration.
 
 ## Destroy the Current Concourse Deployment
-1. Open file `terraform-modules/concourse/dr_create/credhub_encryption_key.tf`.
-1.1 In resource "google_secret_manager_secret_version", comment the "lifecycle" block (to disable `prevent_destroy = true`).
-1.1 Comment module "assertion_encryption_key_identical" (if you receive `Error: Unsupported OpenTofu Core version`).
-1. In `terraform-modules/concourse/infra/database.tf`, set `deletion_protection` and `deletion_protection_enabled` to `false`.
-1. In `terraform-modules/concourse/infra/gke_cluster.tf` add `deletion_protection = false` (the default is `true`).
+1. Credhub secret deletion prevention
+
+   1.1 In `config.yaml` set `credhub_secret_prevent_destroy` to `false` (the default is `true`).
+
+   1.1 Open file `terraform-modules/concourse/dr_create/credhub_encryption_key.tf` Comment module "assertion_encryption_key_identical" (if you receive `Error: Unsupported OpenTofu Core version`).
+1. In `config.yaml`, set `db_terraform_deletion_protection` and `db_engine_level_deletion_protection` to `false` (the default is `true`).
+1. In `config.yaml` set `gke_deletion_protection` to `false` (the default is `true`).
 1. Go to folder `terragrunt/concourse-wg-ci[-test]/infra` and run `terragrunt apply`. This updates the deletion protection settings for the Cloud SQL database and the GKE cluster.
 1. Go to folder `terragrunt/concourse-wg-ci[-test]`. Run `terragrunt run-all plan -destroy` to see what will be destroyed.
 1. If there were no errors, run `terragrunt run-all destroy` to destroy the Concourse deployment in the current region.
@@ -61,10 +63,10 @@ For cost saving reasons, you can migrate the Concourse deployment to a different
    gke_controlplane_version: "1.31"
    ```
 1. Revert the changes in the Terraform files:
-   - In `terraform-modules/concourse/dr_create/credhub_encryption_key.tf`, uncomment the "lifecycle" block.
+   - In `config.yaml` set `credhub_secret_prevent_destroy` to `true`.
    - Uncomment module "assertion_encryption_key_identical" (if you commented it before).
-   - In `terraform-modules/concourse/infra/database.tf`, set `deletion_protection` and `deletion_protection_enabled` to `true`.
-   - In `terraform-modules/concourse/infra/gke_cluster.tf`, remove `deletion_protection = false`.
+   - In `config.yaml`, set `db_terraform_deletion_protection` and `db_engine_level_deletion_protection` to `true`.
+   - In `config.yaml`, set `gke_deletion_protection` to `true`.
 1. Now you can check the Terraform plan:
    ```bash
    terragrunt run-all plan

--- a/terraform-modules/concourse/dr_create/credhub_encryption_key.tf
+++ b/terraform-modules/concourse/dr_create/credhub_encryption_key.tf
@@ -31,7 +31,7 @@ resource "google_secret_manager_secret_version" "credhub_encryption_key" {
   secret      = google_secret_manager_secret.credhub_encryption_key.id
   secret_data = base64decode(data.kubernetes_secret_v1.credhub_encryption_key.binary_data.password)
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.credhub_secret_prevent_destroy
 
     # If omitted or unset terraform destroys previous versions which will make it impossible to
     # restore them. This is relevant in case of a desaster recovery where the

--- a/terraform-modules/concourse/dr_create/variables.tf
+++ b/terraform-modules/concourse/dr_create/variables.tf
@@ -3,3 +3,10 @@ variable "region" { nullable = false }
 variable "zone" { nullable = false }
 
 variable "gke_name" { nullable = false }
+
+variable "credhub_secret_prevent_destroy" {
+  description = "Prevent deletion of credhub encryption key secret version"
+  type        = bool
+  default     = true
+  nullable    = false
+}

--- a/terraform-modules/concourse/infra/database.tf
+++ b/terraform-modules/concourse/infra/database.tf
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "concourse" {
   region           = var.region
 
   # This option prevents Terraform from deleting an instance
-  deletion_protection = true
+  deletion_protection = var.db_terraform_deletion_protection
 
   settings {
     activation_policy = "ALWAYS"
@@ -26,7 +26,7 @@ resource "google_sql_database_instance" "concourse" {
       transaction_log_retention_days = "7"
     }
 
-    deletion_protection_enabled = "true"
+    deletion_protection_enabled = var.db_engine_level_deletion_protection
 
     disk_autoresize       = "true"
     disk_autoresize_limit = "0"

--- a/terraform-modules/concourse/infra/gke_cluster.tf
+++ b/terraform-modules/concourse/infra/gke_cluster.tf
@@ -104,4 +104,6 @@ resource "google_container_cluster" "wg_ci" {
     enabled = "true"
   }
 
+  deletion_protection = var.gke_deletion_protection
+
 }

--- a/terraform-modules/concourse/infra/variables.tf
+++ b/terraform-modules/concourse/infra/variables.tf
@@ -20,6 +20,28 @@ variable "database_version" {
   nullable = false
   default  = "POSTGRES_13"
 }
+
+variable "db_terraform_deletion_protection" {
+  description = "Enable deletion protection for the Cloud SQL instance via Terraform/GCP API"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "db_engine_level_deletion_protection" {
+  description = "Enable engine-level deletion protection for Cloud SQL"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "gke_deletion_protection" {
+  description = "Enable deletion protection for the GKE cluster"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
 variable "sql_instance_name" { nullable = false }
 variable "sql_instance_secondary_zone" { nullable = false }
 variable "sql_instance_backup_location" { nullable = false }

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -47,11 +47,14 @@ tf_modules:
 # ---------------------------------------------------------
 # SQL
 database_version: "POSTGRES_16"
+db_terraform_deletion_protection: true
+db_engine_level_deletion_protection: true
 sql_instance_tier: db-custom-1-4096
 sql_instance_backup_location: eu
 sql_instance_disk_size: 38
 
 # Other GKE vars
+gke_deletion_protection : true
 gke_controlplane_version: "1.31"
 gke_cluster_ipv4_cidr: 10.104.0.0/14
 gke_services_ipv4_cidr_block: 10.108.0.0/20
@@ -76,6 +79,8 @@ gke_cloud_nat_min_ports_per_vm: 16384
 
 # provisioning of loadbalancers
 gke_http_load_balancing_disabled: false
+
+credhub_secret_prevent_destroy: true
 
 # IAM
 wg_ci_human_account_permissions: [

--- a/terragrunt/concourse-wg-ci/dr_create/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci/dr_create/terragrunt.hcl
@@ -35,4 +35,5 @@ inputs = {
   zone    = local.config.zone
 
   gke_name = local.config.gke_name
+  credhub_secret_prevent_destroy = local.config.credhub_secret_prevent_destroy
 }

--- a/terragrunt/concourse-wg-ci/infra/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci/infra/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
   zone    = local.config.zone
 
   gke_name = local.config.gke_name
+  gke_deletion_protection = local.config.gke_deletion_protection
   gke_controlplane_version = local.config.gke_controlplane_version
   gke_cluster_ipv4_cidr = local.config.gke_cluster_ipv4_cidr
   gke_services_ipv4_cidr_block = local.config.gke_services_ipv4_cidr_block
@@ -51,6 +52,8 @@ inputs = {
   gke_http_load_balancing_disabled = local.config.gke_http_load_balancing_disabled
 
   database_version = local.config.database_version
+  db_terraform_deletion_protection = local.config.db_terraform_deletion_protection
+  db_engine_level_deletion_protection = local.config.db_engine_level_deletion_protection
   sql_instance_name = "${local.config.gke_name}-concourse"
   sql_instance_tier = local.config.sql_instance_tier
   sql_instance_disk_size = local.config.sql_instance_disk_size


### PR DESCRIPTION
… gke cluster

- Add variables for Terraform/GCP API and engine-level deletion protection
- Default both protections to true, allowing override via variables
- Add variable for credhub secret deletion
- Add variable for GKE cluster deletion protection
- Default all protections to true, allowing override via input variables

This flags will be exposed and can be overridden/consumed by others.