### PR TITLE
Fix: use literal value for prevent_destroy in lifecycle dr_create

### DIFF
--- a/docs/concourse/region_change.md
+++ b/docs/concourse/region_change.md
@@ -38,9 +38,9 @@ For cost saving reasons, you can migrate the Concourse deployment to a different
 ## Destroy the Current Concourse Deployment
 1. Credhub secret deletion prevention
 
-   1.1 In `config.yaml` set `credhub_secret_prevent_destroy` to `false` (the default is `true`).
-
-   1.1 Open file `terraform-modules/concourse/dr_create/credhub_encryption_key.tf` Comment module "assertion_encryption_key_identical" (if you receive `Error: Unsupported OpenTofu Core version`).
+   1.1 Open file `terraform-modules/concourse/dr_create/credhub_encryption_key.tf`.
+   1.1 In resource "google_secret_manager_secret_version", comment the "lifecycle" block (to disable `prevent_destroy = true`).
+   1.1 Comment module "assertion_encryption_key_identical" (if you receive `Error: Unsupported OpenTofu Core version`).
 1. In `config.yaml`, set `db_terraform_deletion_protection` and `db_engine_level_deletion_protection` to `false` (the default is `true`).
 1. In `config.yaml` set `gke_deletion_protection` to `false` (the default is `true`).
 1. Go to folder `terragrunt/concourse-wg-ci[-test]/infra` and run `terragrunt apply`. This updates the deletion protection settings for the Cloud SQL database and the GKE cluster.
@@ -63,7 +63,7 @@ For cost saving reasons, you can migrate the Concourse deployment to a different
    gke_controlplane_version: "1.31"
    ```
 1. Revert the changes in the Terraform files:
-   - In `config.yaml` set `credhub_secret_prevent_destroy` to `true`.
+   - In `terraform-modules/concourse/dr_create/credhub_encryption_key.tf`, uncomment the "lifecycle" block.
    - Uncomment module "assertion_encryption_key_identical" (if you commented it before).
    - In `config.yaml`, set `db_terraform_deletion_protection` and `db_engine_level_deletion_protection` to `true`.
    - In `config.yaml`, set `gke_deletion_protection` to `true`.

--- a/terraform-modules/concourse/dr_create/credhub_encryption_key.tf
+++ b/terraform-modules/concourse/dr_create/credhub_encryption_key.tf
@@ -31,7 +31,7 @@ resource "google_secret_manager_secret_version" "credhub_encryption_key" {
   secret      = google_secret_manager_secret.credhub_encryption_key.id
   secret_data = base64decode(data.kubernetes_secret_v1.credhub_encryption_key.binary_data.password)
   lifecycle {
-    prevent_destroy = var.credhub_secret_prevent_destroy
+    prevent_destroy = true
 
     # If omitted or unset terraform destroys previous versions which will make it impossible to
     # restore them. This is relevant in case of a desaster recovery where the

--- a/terraform-modules/concourse/dr_create/variables.tf
+++ b/terraform-modules/concourse/dr_create/variables.tf
@@ -4,9 +4,3 @@ variable "zone" { nullable = false }
 
 variable "gke_name" { nullable = false }
 
-variable "credhub_secret_prevent_destroy" {
-  description = "Prevent deletion of credhub encryption key secret version"
-  type        = bool
-  default     = true
-  nullable    = false
-}

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -80,7 +80,6 @@ gke_cloud_nat_min_ports_per_vm: 16384
 # provisioning of loadbalancers
 gke_http_load_balancing_disabled: false
 
-credhub_secret_prevent_destroy: true
 
 # IAM
 wg_ci_human_account_permissions: [

--- a/terragrunt/concourse-wg-ci/dr_create/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci/dr_create/terragrunt.hcl
@@ -35,5 +35,4 @@ inputs = {
   zone    = local.config.zone
 
   gke_name = local.config.gke_name
-  credhub_secret_prevent_destroy = local.config.credhub_secret_prevent_destroy
 }


### PR DESCRIPTION
This change updates the Terraform lifecycle block for the google_secret_manager_secret_version resource to use a literal value for prevent_destroy instead of a variable. Terraform does not support variables in lifecycle meta-arguments, so this fix ensures compatibility and prevents errors during plan and apply.