### PR TITLE
add configurable max days/number of logs to retain build logs globally

### DIFF
--- a/terraform-modules/concourse/app/concourse.tf
+++ b/terraform-modules/concourse/app/concourse.tf
@@ -63,6 +63,14 @@ data "helm_template" "concourse" {
       value = var.concourse_max_days_to_retain_build_logs
     }
   }
+
+  dynamic "set" {
+    for_each = var.concourse_max_build_logs_to_retain != null ? [1] : []
+    content {
+      name  = "concourse.web.maxBuildLogsToRetain"
+      value = var.concourse_max_build_logs_to_retain
+    }
+  }
 }
 
 data "carvel_ytt" "concourse_app" {

--- a/terraform-modules/concourse/app/variables.tf
+++ b/terraform-modules/concourse/app/variables.tf
@@ -22,3 +22,9 @@ variable "concourse_max_days_to_retain_build_logs" {
   type        = number
   default     = null
 }
+
+variable "concourse_max_build_logs_to_retain" {
+  description = "Optional: Max build logs to retain in Concourse"
+  type        = number
+  default     = null
+}

--- a/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci-test/app/terragrunt.hcl
@@ -53,4 +53,5 @@ inputs = {
   concourse_github_mainTeamUser = local.config.concourse_github_mainTeamUser
   concourse_container_placement_strategy = local.config.concourse_container_placement_strategy
   concourse_max_days_to_retain_build_logs = local.config.concourse_max_days_to_retain_build_logs
+  concourse_max_build_logs_to_retain = local.config.concourse_max_build_logs_to_retain
 }

--- a/terragrunt/concourse-wg-ci-test/config.yaml
+++ b/terragrunt/concourse-wg-ci-test/config.yaml
@@ -26,6 +26,10 @@ concourse_container_placement_strategy: "volume-locality"
 # Optional: Set the maximum number of days to retain Concourse build logs.
 # If not set, the default Concourse is configured to feel very snappy!.
 concourse_max_days_to_retain_build_logs: 30
+# Optional: Set the maximum number of build logs to retain.
+# If not set or set to 0, the default Concourse is configured to feel very snappy!.
+concourse_max_build_logs_to_retain: 200
+
 # Concourse helm chart
 concourse_helm_version: "18.1.1"
 

--- a/terragrunt/concourse-wg-ci/app/terragrunt.hcl
+++ b/terragrunt/concourse-wg-ci/app/terragrunt.hcl
@@ -53,4 +53,5 @@ inputs = {
   concourse_github_mainTeamUser = local.config.concourse_github_mainTeamUser
   concourse_container_placement_strategy = local.config.concourse_container_placement_strategy
   concourse_max_days_to_retain_build_logs = local.config.concourse_max_days_to_retain_build_logs
+  concourse_max_build_logs_to_retain = local.config.concourse_max_build_logs_to_retain
 }

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -24,8 +24,11 @@ concourse_github_mainTeamUser: ""
 # The cloud controller unit tests cause a high system load on workers, so place them on workers with few containers
 concourse_container_placement_strategy: "fewest-build-containers"
 # Optional: Set the maximum number of days to retain Concourse build logs.
-# If not set, the default Concourse is configured to feel very snappy!.
+# If not set or set to 0, the default Concourse is configured to feel very snappy!.
 concourse_max_days_to_retain_build_logs: 30
+# Optional: Set the maximum number of build logs to retain.
+# If not set or set to 0, the default Concourse is configured to feel very snappy!.
+concourse_max_build_logs_to_retain: 200
 
 # Concourse helm chart
 concourse_helm_version: "18.1.1"


### PR DESCRIPTION
This change introduces a new optional configuration parameter, concourse_max_days_to_retain_build_logs. It allows operators to control how many days Concourse retains build logs by passing the value to the Helm chart keeping the configuration flexible and user-friendly.