### PR TITLE
Update buildpack team names in concourse-wg-ci

### DIFF
--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -17,7 +17,7 @@ dns_domain: ci.cloudfoundry.org
 gke_name: wg-ci
 
 # Concourse teams
-concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers\\,cloudfoundry:wg-app-runtime-interfaces-capi-approvers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-node-js-reviewers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-node-js-approvers"
+concourse_github_mainTeam: "cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers\\,cloudfoundry:wg-app-runtime-interfaces-capi-approvers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-and-stacks-reviewers\\,cloudfoundry:wg-app-runtime-interfaces-buildpacks-and-stacks-approvers"
 concourse_github_mainTeamUser: ""
 
 # Concourse worker placement strategy: https://concourse-ci.org/container-placement.html


### PR DESCRIPTION
Buildpack areas have been merged in ARI WG: https://github.com/cloudfoundry/community/pull/1319